### PR TITLE
Add humanoid ball throw task

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Humanoid ball throw environment."""
+
+import gymnasium as gym
+
+from . import agents
+
+# Register Gym environment
+
+gym.register(
+    id="Isaac-Humanoid-Throw-Direct-v0",
+    entry_point=f"{__name__}.humanoid_throw_env:HumanoidThrowEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.humanoid_throw_env_cfg:HumanoidThrowEnvCfg",
+        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "skrl_ippo_cfg_entry_point": f"{agents.__name__}:skrl_ippo_cfg.yaml",
+        "skrl_mappo_cfg_entry_point": f"{agents.__name__}:skrl_mappo_cfg.yaml",
+    },
+)

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/rl_games_ppo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/rl_games_ppo_cfg.yaml
@@ -1,0 +1,81 @@
+params:
+  seed: 42
+
+  # environment wrapper clipping
+  env:
+    clip_observations: 5.0
+    clip_actions: 1.0
+
+  algo:
+    name: a2c_continuous
+
+  model:
+    name: continuous_a2c_logstd
+
+  network:
+    name: actor_critic
+    separate: False
+    space:
+      continuous:
+        mu_activation: None
+        sigma_activation: None
+        mu_init:
+          name: default
+        sigma_init:
+          name: const_initializer
+          val: 0
+        fixed_sigma: True
+    mlp:
+      units: [512, 512, 256, 128]
+      activation: elu
+      d2rl: False
+      initializer:
+        name: default
+      regularizer:
+        name: None
+
+  load_checkpoint: False
+  load_path: ''
+
+  config:
+    name: humanoid_throw
+    env_name: rlgpu
+    device: 'cuda:0'
+    device_name: 'cuda:0'
+    multi_gpu: False
+    ppo: True
+    mixed_precision: False
+    normalize_input: True
+    normalize_value: True
+    value_bootstrap: True
+    num_actors: -1
+    reward_shaper:
+      scale_value: 0.01
+    normalize_advantage: True
+    gamma: 0.99
+    tau : 0.95
+    learning_rate: 5e-4
+    lr_schedule: adaptive
+    schedule_type: standard
+    kl_threshold: 0.016
+    score_to_win: 100000
+    max_epochs: 5000
+    save_best_after: 100
+    save_frequency: 200
+    print_stats: True
+    grad_norm: 1.0
+    entropy_coef: 0.0
+    truncate_grads: True
+    e_clip: 0.2
+    horizon_length: 16
+    minibatch_size: 32768
+    mini_epochs: 5
+    critic_coef: 4
+    clip_value: True
+    seq_length: 4
+    bounds_loss_coef: 0.0001
+
+    player:
+      deterministic: True
+      games_num: 100000
+      print_stats: True

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_ippo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_ippo_cfg.yaml
@@ -1,0 +1,67 @@
+seed: 42
+
+models:
+  separate: False
+  policy:
+    class: GaussianMixin
+    clip_actions: False
+    clip_log_std: True
+    min_log_std: -20.0
+    max_log_std: 2.0
+    initial_log_std: 0.0
+    network:
+      - name: net
+        input: STATES
+        layers: [512, 256, 128]
+        activations: elu
+    output: ACTIONS
+  value:
+    class: DeterministicMixin
+    clip_actions: False
+    network:
+      - name: net
+        input: STATES
+        layers: [512, 256, 128]
+        activations: elu
+    output: ONE
+
+memory:
+  class: RandomMemory
+  memory_size: -1
+
+agent:
+  class: IPPO
+  rollouts: 16
+  learning_epochs: 5
+  mini_batches: 4
+  discount_factor: 0.99
+  lambda: 0.95
+  learning_rate: 5.0e-04
+  learning_rate_scheduler: KLAdaptiveLR
+  learning_rate_scheduler_kwargs:
+    kl_threshold: 0.016
+  state_preprocessor: RunningStandardScaler
+  state_preprocessor_kwargs: null
+  value_preprocessor: RunningStandardScaler
+  value_preprocessor_kwargs: null
+  random_timesteps: 0
+  learning_starts: 0
+  grad_norm_clip: 1.0
+  ratio_clip: 0.2
+  value_clip: 0.2
+  clip_predicted_values: True
+  entropy_loss_scale: 0.0
+  value_loss_scale: 2.0
+  kl_threshold: 0.0
+  rewards_shaper_scale: 1.0
+  time_limit_bootstrap: False
+  experiment:
+    directory: "humanoid_throw"
+    experiment_name: ""
+    write_interval: auto
+    checkpoint_interval: auto
+
+trainer:
+  class: SequentialTrainer
+  timesteps: 36000
+  environment_info: log

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_mappo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_mappo_cfg.yaml
@@ -1,0 +1,69 @@
+seed: 42
+
+models:
+  separate: True
+  policy:
+    class: GaussianMixin
+    clip_actions: False
+    clip_log_std: True
+    min_log_std: -20.0
+    max_log_std: 2.0
+    initial_log_std: 0.0
+    network:
+      - name: net
+        input: STATES
+        layers: [512, 512, 256, 128]
+        activations: elu
+    output: ACTIONS
+  value:
+    class: DeterministicMixin
+    clip_actions: False
+    network:
+      - name: net
+        input: STATES
+        layers: [512, 512, 256, 128]
+        activations: elu
+    output: ONE
+
+memory:
+  class: RandomMemory
+  memory_size: -1
+
+agent:
+  class: MAPPO
+  rollouts: 16
+  learning_epochs: 5
+  mini_batches: 4
+  discount_factor: 0.99
+  lambda: 0.95
+  learning_rate: 5.0e-04
+  learning_rate_scheduler: KLAdaptiveLR
+  learning_rate_scheduler_kwargs:
+    kl_threshold: 0.016
+  state_preprocessor: RunningStandardScaler
+  state_preprocessor_kwargs: null
+  shared_state_preprocessor: RunningStandardScaler
+  shared_state_preprocessor_kwargs: null
+  value_preprocessor: RunningStandardScaler
+  value_preprocessor_kwargs: null
+  random_timesteps: 0
+  learning_starts: 0
+  grad_norm_clip: 1.0
+  ratio_clip: 0.2
+  value_clip: 0.2
+  clip_predicted_values: True
+  entropy_loss_scale: 0.0
+  value_loss_scale: 2.0
+  kl_threshold: 0.0
+  rewards_shaper_scale: 1.0
+  time_limit_bootstrap: False
+  experiment:
+    directory: "humanoid_throw"
+    experiment_name: ""
+    write_interval: auto
+    checkpoint_interval: auto
+
+trainer:
+  class: SequentialTrainer
+  timesteps: 36000
+  environment_info: log

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_ppo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_ppo_cfg.yaml
@@ -1,0 +1,68 @@
+seed: 42
+
+# Models are instantiated using skrl's model instantiator utility
+models:
+  separate: False
+  policy:
+    class: GaussianMixin
+    clip_actions: False
+    clip_log_std: True
+    min_log_std: -20.0
+    max_log_std: 2.0
+    initial_log_std: 0.0
+    network:
+      - name: net
+        input: STATES
+        layers: [512, 512, 256, 128]
+        activations: elu
+    output: ACTIONS
+  value:
+    class: DeterministicMixin
+    clip_actions: False
+    network:
+      - name: net
+        input: STATES
+        layers: [512, 512, 256, 128]
+        activations: elu
+    output: ONE
+
+memory:
+  class: RandomMemory
+  memory_size: -1
+
+agent:
+  class: PPO
+  rollouts: 16
+  learning_epochs: 5
+  mini_batches: 4
+  discount_factor: 0.99
+  lambda: 0.95
+  learning_rate: 5.0e-04
+  learning_rate_scheduler: KLAdaptiveLR
+  learning_rate_scheduler_kwargs:
+    kl_threshold: 0.016
+  state_preprocessor: RunningStandardScaler
+  state_preprocessor_kwargs: null
+  value_preprocessor: RunningStandardScaler
+  value_preprocessor_kwargs: null
+  random_timesteps: 0
+  learning_starts: 0
+  grad_norm_clip: 1.0
+  ratio_clip: 0.2
+  value_clip: 0.2
+  clip_predicted_values: True
+  entropy_loss_scale: 0.0
+  value_loss_scale: 2.0
+  kl_threshold: 0.0
+  rewards_shaper_scale: 1.0
+  time_limit_bootstrap: False
+  experiment:
+    directory: "humanoid_throw"
+    experiment_name: ""
+    write_interval: auto
+    checkpoint_interval: auto
+
+trainer:
+  class: SequentialTrainer
+  timesteps: 36000
+  environment_info: log

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/humanoid_throw_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/humanoid_throw_env.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+from collections.abc import Sequence
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import DirectMARLEnv
+from isaaclab.sim.spawners.from_files import GroundPlaneCfg, spawn_ground_plane
+
+from .humanoid_throw_env_cfg import HumanoidThrowEnvCfg
+
+
+class HumanoidThrowEnv(DirectMARLEnv):
+    """Environment where two humanoids throw a ball to each other."""
+
+    cfg: HumanoidThrowEnvCfg
+
+    def __init__(self, cfg: HumanoidThrowEnvCfg, render_mode: str | None = None, **kwargs):
+        super().__init__(cfg, render_mode, **kwargs)
+
+        self.num_dofs = self.thrower.num_joints
+        self.thrower_targets = torch.zeros((self.num_envs, self.num_dofs), device=self.device)
+        self.catcher_targets = torch.zeros((self.num_envs, self.num_dofs), device=self.device)
+
+        joint_limits = self.thrower.root_physx_view.get_dof_limits().to(self.device)
+        self.dof_lower = joint_limits[..., 0]
+        self.dof_upper = joint_limits[..., 1]
+
+        self.ball_init_pos = torch.tensor([0.0, -0.5, 1.5], dtype=torch.float, device=self.device)
+
+    #
+    # implementation details
+    #
+    def _setup_scene(self):
+        self.thrower = Articulation(self.cfg.thrower_robot_cfg)
+        self.catcher = Articulation(self.cfg.catcher_robot_cfg)
+        self.ball = RigidObject(self.cfg.ball_cfg)
+        spawn_ground_plane(prim_path="/World/ground", cfg=GroundPlaneCfg())
+        self.scene.clone_environments(copy_from_source=False)
+        self.scene.articulations["thrower"] = self.thrower
+        self.scene.articulations["catcher"] = self.catcher
+        self.scene.rigid_objects["ball"] = self.ball
+        light_cfg = sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75))
+        light_cfg.func("/World/Light", light_cfg)
+
+    def _pre_physics_step(self, actions: dict[str, torch.Tensor]) -> None:
+        self.actions = actions
+
+    def _apply_action(self) -> None:
+        self.thrower_targets = scale(self.actions["thrower"], self.dof_lower, self.dof_upper)
+        self.catcher_targets = scale(self.actions["catcher"], self.dof_lower, self.dof_upper)
+        self.thrower.set_joint_position_target(self.thrower_targets)
+        self.catcher.set_joint_position_target(self.catcher_targets)
+
+    def _get_observations(self) -> dict[str, torch.Tensor]:
+        ball_pos = self.ball.data.root_pos_w - self.scene.env_origins
+        ball_vel = self.ball.data.root_lin_vel_w
+        obs_thrower = torch.cat(
+            (
+                unscale(self.thrower.data.joint_pos, self.dof_lower, self.dof_upper),
+                self.cfg.vel_obs_scale * self.thrower.data.joint_vel,
+                ball_pos,
+                ball_vel,
+            ),
+            dim=-1,
+        )
+        obs_catcher = torch.cat(
+            (
+                unscale(self.catcher.data.joint_pos, self.dof_lower, self.dof_upper),
+                self.cfg.vel_obs_scale * self.catcher.data.joint_vel,
+                ball_pos,
+                ball_vel,
+            ),
+            dim=-1,
+        )
+        return {"thrower": obs_thrower, "catcher": obs_catcher}
+
+    def _get_rewards(self) -> dict[str, torch.Tensor]:
+        ball_pos = self.ball.data.root_pos_w
+        goal = self.catcher.data.root_pos_w + torch.tensor([0.0, 0.5, 1.0], device=self.device)
+        dist = torch.norm(ball_pos - goal, dim=-1)
+        reward = 1.0 - torch.tanh(dist)
+        return {"thrower": reward, "catcher": reward}
+
+    def _get_dones(self) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+        time_out = self.episode_length_buf >= self.max_episode_length - 1
+        ball_pos = self.ball.data.root_pos_w
+        fallen = ball_pos[:, 2] < 0.2
+        terminated = {agent: fallen for agent in self.cfg.possible_agents}
+        time_outs = {agent: time_out for agent in self.cfg.possible_agents}
+        return terminated, time_outs
+
+    def _reset_idx(self, env_ids: Sequence[int] | None):
+        if env_ids is None:
+            env_ids = self.ball._ALL_INDICES
+        super()._reset_idx(env_ids)
+        self.thrower.reset(env_ids)
+        self.catcher.reset(env_ids)
+        ball_state = self.ball.data.default_root_state[env_ids]
+        ball_state[:, :3] = self.ball_init_pos + self.scene.env_origins[env_ids]
+        ball_state[:, 3:7] = torch.tensor([1.0, 0.0, 0.0, 0.0], device=self.device)
+        ball_state[:, 7:] = 0
+        self.ball.write_root_pose_to_sim(ball_state[:, :7], env_ids)
+        self.ball.write_root_velocity_to_sim(ball_state[:, 7:], env_ids)
+
+
+@torch.jit.script
+def scale(x, lower, upper):
+    return 0.5 * (x + 1.0) * (upper - lower) + lower
+
+
+@torch.jit.script
+def unscale(x, lower, upper):
+    return (2.0 * x - upper - lower) / (upper - lower)

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/humanoid_throw_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/humanoid_throw_env_cfg.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab_assets import HUMANOID_CFG
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, RigidObjectCfg
+from isaaclab.envs import DirectMARLEnvCfg
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sim import SimulationCfg
+from isaaclab.utils import configclass
+
+
+@configclass
+class HumanoidThrowEnvCfg(DirectMARLEnvCfg):
+    """Configuration for humanoid ball throw environment."""
+
+    # env
+    decimation = 2
+    episode_length_s = 10.0
+    possible_agents = ["thrower", "catcher"]
+    action_spaces = {"thrower": 21, "catcher": 21}
+    observation_spaces = {"thrower": 48, "catcher": 48}
+    state_space = 0
+    vel_obs_scale = 0.1
+
+    # simulation
+    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation)
+
+    # robots
+    thrower_robot_cfg: ArticulationCfg = HUMANOID_CFG.replace(prim_path="/World/envs/env_.*/Thrower").replace(
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=(0.0, 0.0, 1.0),
+            rot=(1.0, 0.0, 0.0, 0.0),
+            joint_pos={".*": 0.0},
+        )
+    )
+    catcher_robot_cfg: ArticulationCfg = HUMANOID_CFG.replace(prim_path="/World/envs/env_.*/Catcher").replace(
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=(0.0, -2.0, 1.0),
+            rot=(0.0, 0.0, 1.0, 0.0),
+            joint_pos={".*": 0.0},
+        )
+    )
+
+    # ball object
+    ball_cfg: RigidObjectCfg = RigidObjectCfg(
+        prim_path="/World/envs/env_.*/ball",
+        spawn=sim_utils.SphereCfg(
+            radius=0.1,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.1, 0.1)),
+            physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.7, dynamic_friction=0.5),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=False),
+            mass_props=sim_utils.MassPropertiesCfg(density=500.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+        ),
+    )
+
+    # scene
+    scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=512, env_spacing=8.0, replicate_physics=True)


### PR DESCRIPTION
## Summary
- add multi-agent humanoid ball throw example
- include RL training configs for PPO, IPPO, and MAPPO

## Testing
- `pre-commit run --files source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/__init__.py source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/humanoid_throw_env.py source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/humanoid_throw_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/__init__.py source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/rl_games_ppo_cfg.yaml source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_ppo_cfg.yaml source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_ippo_cfg.yaml source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_throw/agents/skrl_mappo_cfg.yaml`
- `PYTHONPATH=source/isaaclab python -c "from isaaclab.app import AppLauncher"` *(fails: ModuleNotFoundError: No module named 'isaacsim')*

------
https://chatgpt.com/codex/tasks/task_e_68ad5482cf508333a556f50133925e31